### PR TITLE
Better model.__repr__()

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,4 @@ jobs:
           pip install .[test]
 
       - name: Run Tests
-        run: python -m pytest --capture=no --cov
+        run: python -m pytest --capture=no --cov aviary

--- a/aviary/cgcnn/model.py
+++ b/aviary/cgcnn/model.py
@@ -132,7 +132,6 @@ class DescriptorNetwork(nn.Module):
     """
 
     def __init__(self, elem_emb_len, nbr_fea_len, elem_fea_len=64, n_graph=4):
-        """ """
         super().__init__()
 
         self.embedding = nn.Linear(elem_emb_len, elem_fea_len)

--- a/aviary/core.py
+++ b/aviary/core.py
@@ -397,6 +397,11 @@ class BaseModelClass(nn.Module, ABC):
     def num_params(self):
         return sum(p.numel() for p in self.parameters() if p.requires_grad)
 
+    def __repr__(self):
+        name = self._get_name()
+        n_params, n_epochs = self.num_params, self.epoch
+        return f"{name}: {n_params:,} trainable params at {n_epochs:,} epochs"
+
 
 class Normalizer:
     """Normalize a Tensor and restore it later."""

--- a/aviary/core.py
+++ b/aviary/core.py
@@ -10,6 +10,8 @@ from sklearn.metrics import accuracy_score, f1_score
 from torch.nn.functional import softmax
 from tqdm.autonotebook import tqdm
 
+from aviary.segments import SimpleNetwork, WeightedAttentionPooling
+
 
 class BaseModelClass(nn.Module, ABC):
     """
@@ -401,6 +403,77 @@ class BaseModelClass(nn.Module, ABC):
         name = self._get_name()
         n_params, n_epochs = self.num_params, self.epoch
         return f"{name}: {n_params:,} trainable params at {n_epochs:,} epochs"
+
+
+class MessageLayer(nn.Module):
+    """
+    Massage Layers are used to propagate information between nodes in
+    in the stoichiometry graph.
+    """
+
+    def __init__(self, elem_fea_len, elem_heads, elem_gate, elem_msg):
+        super().__init__()
+
+        self._repr = (
+            f"{self._get_name()}(elem_fea_len={elem_fea_len}, "
+            f"elem_heads={elem_heads}, elem_gate={elem_gate}, elem_msg={elem_msg})"
+        )
+
+        # Pooling and Output
+        self.pooling = nn.ModuleList(
+            [
+                WeightedAttentionPooling(
+                    gate_nn=SimpleNetwork(2 * elem_fea_len, 1, elem_gate),
+                    message_nn=SimpleNetwork(2 * elem_fea_len, elem_fea_len, elem_msg),
+                )
+                for _ in range(elem_heads)
+            ]
+        )
+
+    def forward(self, elem_weights, elem_in_fea, self_fea_idx, nbr_fea_idx):
+        """
+        Forward pass
+
+        Parameters
+        ----------
+        N: Total number of elements (nodes) in the batch
+        M: Total number of pairs (edges) in the batch
+        C: Total number of crystals (graphs) in the batch
+
+        Inputs
+        ----------
+        elem_weights: Variable(torch.Tensor) shape (N,)
+            The fractional weights of elements in their materials
+        elem_in_fea: Variable(torch.Tensor) shape (N, elem_fea_len)
+            Element hidden features before message passing
+        self_fea_idx: torch.Tensor shape (M,)
+            Indices of the first element in each of the M pairs
+        nbr_fea_idx: torch.Tensor shape (M,)
+            Indices of the second element in each of the M pairs
+
+        Returns
+        -------
+        elem_out_fea: nn.Variable shape (N, elem_fea_len)
+            Element hidden features after message passing
+        """
+        # construct the total features for passing
+        elem_nbr_weights = elem_weights[nbr_fea_idx, :]
+        elem_nbr_fea = elem_in_fea[nbr_fea_idx, :]
+        elem_self_fea = elem_in_fea[self_fea_idx, :]
+        fea = torch.cat([elem_self_fea, elem_nbr_fea], dim=1)
+
+        # sum selectivity over the neighbours to get elements
+        head_fea = []
+        for attnhead in self.pooling:
+            head_fea.append(attnhead(fea, index=self_fea_idx, weights=elem_nbr_weights))
+
+        # average the attention heads
+        fea = torch.mean(torch.stack(head_fea), dim=0)
+
+        return fea + elem_in_fea
+
+    def __repr__(self):
+        return self._repr
 
 
 class Normalizer:

--- a/aviary/roost/model.py
+++ b/aviary/roost/model.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from aviary.core import BaseModelClass
+from aviary.core import BaseModelClass, MessageLayer
 from aviary.segments import ResidualNetwork, SimpleNetwork, WeightedAttentionPooling
 
 
@@ -187,72 +187,6 @@ class DescriptorNetwork(nn.Module):
             )
 
         return torch.mean(torch.stack(head_fea), dim=0)
-
-    def __repr__(self):
-        return self.__class__.__name__
-
-
-class MessageLayer(nn.Module):
-    """
-    Massage Layers are used to propagate information between nodes in
-    the stoichiometry graph.
-    """
-
-    def __init__(self, elem_fea_len, elem_heads, elem_gate, elem_msg):
-        super().__init__()
-
-        # Pooling and Output
-        self.pooling = nn.ModuleList(
-            [
-                WeightedAttentionPooling(
-                    gate_nn=SimpleNetwork(2 * elem_fea_len, 1, elem_gate),
-                    message_nn=SimpleNetwork(2 * elem_fea_len, elem_fea_len, elem_msg),
-                )
-                for _ in range(elem_heads)
-            ]
-        )
-
-    def forward(self, elem_weights, elem_in_fea, self_fea_idx, nbr_fea_idx):
-        """
-        Forward pass
-
-        Parameters
-        ----------
-        N: Total number of elements (nodes) in the batch
-        M: Total number of pairs (edges) in the batch
-        C: Total number of crystals (graphs) in the batch
-
-        Inputs
-        ----------
-        elem_weights: Variable(torch.Tensor) shape (N,)
-            The fractional weights of elems in their materials
-        elem_in_fea: Variable(torch.Tensor) shape (N, elem_fea_len)
-            Element hidden features before message passing
-        self_fea_idx: torch.Tensor shape (M,)
-            Indices of the first element in each of the M pairs
-        nbr_fea_idx: torch.Tensor shape (M,)
-            Indices of the second element in each of the M pairs
-
-        Returns
-        -------
-        elem_out_fea: nn.Variable shape (N, elem_fea_len)
-            Element hidden features after message passing
-        """
-        # construct the total features for passing
-        elem_nbr_weights = elem_weights[nbr_fea_idx, :]
-        elem_nbr_fea = elem_in_fea[nbr_fea_idx, :]
-        elem_self_fea = elem_in_fea[self_fea_idx, :]
-        fea = torch.cat([elem_self_fea, elem_nbr_fea], dim=1)
-
-        # sum selectivity over the neighbours to get elems
-        head_fea = []
-        for attnhead in self.pooling:
-            head_fea.append(attnhead(fea, index=self_fea_idx, weights=elem_nbr_weights))
-
-        # average the attention heads
-        fea = torch.mean(torch.stack(head_fea), dim=0)
-
-        return fea + elem_in_fea
 
     def __repr__(self):
         return self.__class__.__name__

--- a/aviary/roost/model.py
+++ b/aviary/roost/model.py
@@ -2,8 +2,13 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from aviary.core import BaseModelClass, MessageLayer
-from aviary.segments import ResidualNetwork, SimpleNetwork, WeightedAttentionPooling
+from aviary.core import BaseModelClass
+from aviary.segments import (
+    MessageLayer,
+    ResidualNetwork,
+    SimpleNetwork,
+    WeightedAttentionPooling,
+)
 
 
 class Roost(BaseModelClass):

--- a/aviary/roost/model.py
+++ b/aviary/roost/model.py
@@ -32,7 +32,7 @@ class Roost(BaseModelClass):
         cry_msg=[256],
         trunk_hidden=[1024, 512],
         out_hidden=[256, 128, 64],
-        **kwargs
+        **kwargs,
     ):
         if isinstance(out_hidden[0], list):
             raise ValueError("boo hiss bad user")
@@ -90,9 +90,6 @@ class Roost(BaseModelClass):
 
         # apply neural network to map from learned features to target
         return (output_nn(crys_fea) for output_nn in self.output_nns)
-
-    def __repr__(self):
-        return self.__class__.__name__
 
 
 class DescriptorNetwork(nn.Module):

--- a/aviary/segments.py
+++ b/aviary/segments.py
@@ -94,6 +94,77 @@ class WeightedAttentionPooling(nn.Module):
         return self.__class__.__name__
 
 
+class MessageLayer(nn.Module):
+    """
+    Massage Layers are used to propagate information between nodes in
+    in the stoichiometry graph.
+    """
+
+    def __init__(self, elem_fea_len, elem_heads, elem_gate, elem_msg):
+        super().__init__()
+
+        self._repr = (
+            f"{self._get_name()}(elem_fea_len={elem_fea_len}, "
+            f"elem_heads={elem_heads}, elem_gate={elem_gate}, elem_msg={elem_msg})"
+        )
+
+        # Pooling and Output
+        self.pooling = nn.ModuleList(
+            [
+                WeightedAttentionPooling(
+                    gate_nn=SimpleNetwork(2 * elem_fea_len, 1, elem_gate),
+                    message_nn=SimpleNetwork(2 * elem_fea_len, elem_fea_len, elem_msg),
+                )
+                for _ in range(elem_heads)
+            ]
+        )
+
+    def forward(self, elem_weights, elem_in_fea, self_fea_idx, nbr_fea_idx):
+        """
+        Forward pass
+
+        Parameters
+        ----------
+        N: Total number of elements (nodes) in the batch
+        M: Total number of pairs (edges) in the batch
+        C: Total number of crystals (graphs) in the batch
+
+        Inputs
+        ----------
+        elem_weights: Variable(torch.Tensor) shape (N,)
+            The fractional weights of elements in their materials
+        elem_in_fea: Variable(torch.Tensor) shape (N, elem_fea_len)
+            Element hidden features before message passing
+        self_fea_idx: torch.Tensor shape (M,)
+            Indices of the first element in each of the M pairs
+        nbr_fea_idx: torch.Tensor shape (M,)
+            Indices of the second element in each of the M pairs
+
+        Returns
+        -------
+        elem_out_fea: nn.Variable shape (N, elem_fea_len)
+            Element hidden features after message passing
+        """
+        # construct the total features for passing
+        elem_nbr_weights = elem_weights[nbr_fea_idx, :]
+        elem_nbr_fea = elem_in_fea[nbr_fea_idx, :]
+        elem_self_fea = elem_in_fea[self_fea_idx, :]
+        fea = torch.cat([elem_self_fea, elem_nbr_fea], dim=1)
+
+        # sum selectivity over the neighbours to get elements
+        head_fea = []
+        for attnhead in self.pooling:
+            head_fea.append(attnhead(fea, index=self_fea_idx, weights=elem_nbr_weights))
+
+        # average the attention heads
+        fea = torch.mean(torch.stack(head_fea), dim=0)
+
+        return fea + elem_in_fea
+
+    def __repr__(self):
+        return self._repr
+
+
 class SimpleNetwork(nn.Module):
     """
     Simple Feed Forward Neural Network

--- a/aviary/wren/model.py
+++ b/aviary/wren/model.py
@@ -110,9 +110,6 @@ class Wren(BaseModelClass):
         # apply neural network to map from learned features to target
         return (output_nn(crys_fea) for output_nn in self.output_nns)
 
-    def __repr__(self):
-        return f"{self.__class__.__name__}"
-
 
 class DescriptorNetwork(nn.Module):
     """

--- a/aviary/wren/model.py
+++ b/aviary/wren/model.py
@@ -2,9 +2,10 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from aviary.core import BaseModelClass, MessageLayer
+from aviary.core import BaseModelClass
 from aviary.segments import (
     MeanPooling,
+    MessageLayer,
     ResidualNetwork,
     SimpleNetwork,
     WeightedAttentionPooling,

--- a/aviary/wren/model.py
+++ b/aviary/wren/model.py
@@ -18,7 +18,7 @@ class Wren(BaseModelClass):
 
     The message passing layers are used to determine a descriptor set
     for the fully connected network. The graphs are used to represent
-    the stiochiometry of inorganic materials in a trainable manner.
+    the stoichiometry of inorganic materials in a trainable manner.
     This makes them systematically improvable with more data.
     """
 
@@ -184,11 +184,11 @@ class DescriptorNetwork(nn.Module):
 
         Args:
             elem_weights (torch.Tensor): Fractional weight of each
-                Element in its stiochiometry
+                Element in its stoichiometry
             elem_fea (torch.Tensor): Element features of each of
-                the N elems in the batch
+                the N elements in the batch
             sym_fea (torch.Tensor): Wyckoff Position features of each
-                of the N elems in the batch
+                of the N elements in the batch
             self_fea_idx (torch.Tensor): Indices of the first element in
                 each of the M pairs
             nbr_fea_idx (torch.Tensor): Indices of the second element in
@@ -236,7 +236,7 @@ class DescriptorNetwork(nn.Module):
 class MessageLayer(nn.Module):
     """
     Massage Layers are used to propagate information between nodes in
-    in the stiochiometry graph.
+    in the stoichiometry graph.
     """
 
     def __init__(self, elem_fea_len, elem_heads, elem_gate, elem_msg):
@@ -269,7 +269,7 @@ class MessageLayer(nn.Module):
         Inputs
         ----------
         elem_weights: Variable(torch.Tensor) shape (N,)
-            The fractional weights of elems in their materials
+            The fractional weights of elements in their materials
         elem_in_fea: Variable(torch.Tensor) shape (N, elem_fea_len)
             Element hidden features before message passing
         self_fea_idx: torch.Tensor shape (M,)
@@ -288,7 +288,7 @@ class MessageLayer(nn.Module):
         elem_self_fea = elem_in_fea[self_fea_idx, :]
         fea = torch.cat([elem_self_fea, elem_nbr_fea], dim=1)
 
-        # sum selectivity over the neighbours to get elems
+        # sum selectivity over the neighbours to get elements
         head_fea = []
         for attnhead in self.pooling:
             head_fea.append(attnhead(fea, index=self_fea_idx, weights=elem_nbr_weights))

--- a/aviary/wren/model.py
+++ b/aviary/wren/model.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from aviary.core import BaseModelClass
+from aviary.core import BaseModelClass, MessageLayer
 from aviary.segments import (
     MeanPooling,
     ResidualNetwork,
@@ -131,7 +131,6 @@ class DescriptorNetwork(nn.Module):
         cry_gate=[256],
         cry_msg=[256],
     ):
-        """ """
         super().__init__()
 
         # apply linear transform to the input to get a trainable embedding
@@ -228,75 +227,6 @@ class DescriptorNetwork(nn.Module):
         cry_fea = self.aug_pool(torch.mean(torch.stack(head_fea), dim=0), aug_cry_idx)
 
         return cry_fea
-
-    def __repr__(self):
-        return f"{self.__class__.__name__}"
-
-
-class MessageLayer(nn.Module):
-    """
-    Massage Layers are used to propagate information between nodes in
-    in the stoichiometry graph.
-    """
-
-    def __init__(self, elem_fea_len, elem_heads, elem_gate, elem_msg):
-        """ """
-        super().__init__()
-
-        # Pooling and Output
-        self.pooling = nn.ModuleList(
-            [
-                WeightedAttentionPooling(
-                    gate_nn=SimpleNetwork(2 * elem_fea_len, 1, elem_gate),
-                    message_nn=SimpleNetwork(2 * elem_fea_len, elem_fea_len, elem_msg),
-                    # message_nn=nn.Linear(2*elem_fea_len, elem_fea_len),
-                    # message_nn=nn.Identity(),
-                )
-                for _ in range(elem_heads)
-            ]
-        )
-
-    def forward(self, elem_weights, elem_in_fea, self_fea_idx, nbr_fea_idx):
-        """
-        Forward pass
-
-        Parameters
-        ----------
-        N: Total number of elements (nodes) in the batch
-        M: Total number of pairs (edges) in the batch
-        C: Total number of crystals (graphs) in the batch
-
-        Inputs
-        ----------
-        elem_weights: Variable(torch.Tensor) shape (N,)
-            The fractional weights of elements in their materials
-        elem_in_fea: Variable(torch.Tensor) shape (N, elem_fea_len)
-            Element hidden features before message passing
-        self_fea_idx: torch.Tensor shape (M,)
-            Indices of the first element in each of the M pairs
-        nbr_fea_idx: torch.Tensor shape (M,)
-            Indices of the second element in each of the M pairs
-
-        Returns
-        -------
-        elem_out_fea: nn.Variable shape (N, elem_fea_len)
-            Element hidden features after message passing
-        """
-        # construct the total features for passing
-        elem_nbr_weights = elem_weights[nbr_fea_idx, :]
-        elem_nbr_fea = elem_in_fea[nbr_fea_idx, :]
-        elem_self_fea = elem_in_fea[self_fea_idx, :]
-        fea = torch.cat([elem_self_fea, elem_nbr_fea], dim=1)
-
-        # sum selectivity over the neighbours to get elements
-        head_fea = []
-        for attnhead in self.pooling:
-            head_fea.append(attnhead(fea, index=self_fea_idx, weights=elem_nbr_weights))
-
-        # average the attention heads
-        fea = torch.mean(torch.stack(head_fea), dim=0)
-
-        return fea + elem_in_fea
 
     def __repr__(self):
         return f"{self.__class__.__name__}"


### PR DESCRIPTION
`model.__repr__()` now includes trainable params and epoch count. Moved from `Wren` + `Roost` having identical implementations to SSOT on `BaseModelClass` so CGCNN now has custom `__repr__` too.

Also confines coverage reporting in CI to package files (i.e. exclude test files).