### PR TITLE
Better `nn.Module` reprs - take 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,7 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
-        args: ['--ignore=E501,W503,E203']
-      # E501 let black handle all line length decisions
+        args: [--ignore, 'W503,E203']
       # W503 black conflicts with "line break before operator" rule
       # E203 black conflicts with "whitespace before ':'" rule
 

--- a/aviary/cgcnn/data.py
+++ b/aviary/cgcnn/data.py
@@ -95,7 +95,8 @@ class CrystalGraphData(Dataset):
         return len(self.df)
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}(df={self.df.shape}, task_dict={self.task_dict})"
+        df_repr = f"cols=[{', '.join(self.df.columns)}], len={len(self.df)}"
+        return f"{type(self).__name__}({df_repr}, task_dict={self.task_dict})"
 
     def _get_nbr_data(
         self, crystal: Structure

--- a/aviary/cgcnn/data.py
+++ b/aviary/cgcnn/data.py
@@ -94,6 +94,9 @@ class CrystalGraphData(Dataset):
     def __len__(self) -> int:
         return len(self.df)
 
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(df={self.df.shape}, task_dict={self.task_dict})"
+
     def _get_nbr_data(
         self, crystal: Structure
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:

--- a/aviary/cgcnn/model.py
+++ b/aviary/cgcnn/model.py
@@ -40,11 +40,14 @@ class CrystalGraphConvNet(BaseModelClass):
             n_targets (list[int]): Number of targets to train on
             elem_emb_len (int): Number of atom features in the input.
             nbr_fea_len (int): Number of bond features.
-            elem_fea_len (int, optional): Number of hidden atom features in the convolutional layers. Defaults to 64.
+            elem_fea_len (int, optional): Number of hidden atom features in the convolutional
+                layers. Defaults to 64.
             n_graph (int, optional): Number of convolutional layers. Defaults to 4.
             h_fea_len (int, optional): Number of hidden features after pooling. Defaults to 128.
-            n_trunk (int, optional): Number of hidden layers in trunk after pooling. Defaults to 1.
-            n_hidden (int, optional): Number of hidden layers after trunk for each task. Defaults to 1.
+            n_trunk (int, optional): Number of hidden layers in trunk after pooling.
+                Defaults to 1.
+            n_hidden (int, optional): Number of hidden layers after trunk for each task.
+                Defaults to 1.
         """
         super().__init__(robust=robust, **kwargs)
 

--- a/aviary/core.py
+++ b/aviary/core.py
@@ -41,7 +41,7 @@ class BaseModelClass(nn.Module, ABC):
         """Store core model parameters.
 
         Args:
-            task_dict (dict[str, TaskType]): Map of target names to "regression" or "classification".
+            task_dict (dict[str, TaskType]): Map target names to "regression" or "classification".
             robust (bool): Whether to estimate standard deviation for use in a robust loss function
             device (type[torch.device] | Literal["cuda", "cpu"]): Device the model will run on.
             epoch (int, optional): Epoch model training will begin/resume from. Defaults to 1.
@@ -435,8 +435,10 @@ class Normalizer:
 
         Args:
             tensor (Tensor): Tensor to determine the mean and standard deviation over.
-            dim (int, optional): Which dimension to take mean and standard deviation over. Defaults to 0.
-            keepdim (bool, optional): Whether to keep the reduced dimension in Tensor. Defaults to False.
+            dim (int, optional): Which dimension to take mean and standard deviation over.
+                Defaults to 0.
+            keepdim (bool, optional): Whether to keep the reduced dimension in Tensor.
+                Defaults to False.
         """
         self.mean = torch.mean(tensor, dim, keepdim)
         self.std = torch.std(tensor, dim, keepdim)

--- a/aviary/roost/data.py
+++ b/aviary/roost/data.py
@@ -66,8 +66,11 @@ class CompositionData(Dataset):
                 n_classes = np.max(self.df[target].values) + 1
                 self.n_targets.append(n_classes)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.df)
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(df={self.df.shape}, task_dict={self.task_dict})"
 
     @functools.lru_cache(maxsize=None)  # Cache data for faster training
     def __getitem__(self, idx: int):

--- a/aviary/roost/data.py
+++ b/aviary/roost/data.py
@@ -143,7 +143,8 @@ def collate_batch(
     """Collate a list of data and return a batch for predicting crystal properties.
 
     Args:
-        dataset_list (list): list of tuples for each data point: (elem_fea, nbr_fea, nbr_idx, target)
+        dataset_list (list): list of tuples for each data point where each tuple contains:
+            (elem_fea, nbr_fea, nbr_idx, target)
             - elem_fea (Tensor):  _description_
             - nbr_fea (Tensor):
             - self_idx (LongTensor):

--- a/aviary/roost/data.py
+++ b/aviary/roost/data.py
@@ -70,7 +70,8 @@ class CompositionData(Dataset):
         return len(self.df)
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}(df={self.df.shape}, task_dict={self.task_dict})"
+        df_repr = f"cols=[{', '.join(self.df.columns)}], len={len(self.df)}"
+        return f"{type(self).__name__}({df_repr}, task_dict={self.task_dict})"
 
     @functools.lru_cache(maxsize=None)  # Cache data for faster training
     def __getitem__(self, idx: int):

--- a/aviary/roost/model.py
+++ b/aviary/roost/model.py
@@ -53,12 +53,15 @@ class Roost(BaseModelClass):
         """_summary_
 
         Args:
-            robust (bool): Whether to estimate standard deviation for use in a robust loss function
+            robust (bool): Whether to estimate standard deviation for use in a robust loss function.
             n_targets (list[int]): Number of targets to train on
             elem_emb_len (int): Number of features in initial element embedding
-            elem_fea_len (int, optional): Number of hidden features to use to encode elements. Defaults to 64.
-            n_graph (int, optional): Number of message passing operations to carry out. Defaults to 3.
-            elem_heads (int, optional): Number of parallel attention heads per message passing operation. Defaults to 3.
+            elem_fea_len (int, optional): Number of hidden features to use to encode elements.
+                Defaults to 64.
+            n_graph (int, optional): Number of message passing operations to carry out.
+                Defaults to 3.
+            elem_heads (int, optional): Number of parallel attention heads per message passing
+                operation. Defaults to 3.
             elem_gate (list[int], optional): _description_. Defaults to [256].
             elem_msg (list[int], optional): _description_. Defaults to [256].
             cry_heads (int, optional): _description_. Defaults to 3.

--- a/aviary/roost/model.py
+++ b/aviary/roost/model.py
@@ -237,6 +237,7 @@ class DescriptorNetwork(nn.Module):
 
     def __repr__(self) -> str:
         return (
-            f"{type(self).__name__}(elem_emb_len={self.embedding.in_features}, "
+            f"{type(self).__name__}(n_graph={len(self.graphs)}, cry_heads="
+            f"{len(self.cry_pool)}, elem_emb_len={self.embedding.in_features}, "
             f"elem_fea_len={self.embedding.out_features})"
         )

--- a/aviary/roost/model.py
+++ b/aviary/roost/model.py
@@ -233,4 +233,7 @@ class DescriptorNetwork(nn.Module):
         return torch.mean(torch.stack(head_fea), dim=0)
 
     def __repr__(self) -> str:
-        return self.__class__.__name__
+        return (
+            f"{type(self).__name__}(elem_emb_len={self.embedding.in_features}, "
+            f"elem_fea_len={self.embedding.out_features})"
+        )

--- a/aviary/segments.py
+++ b/aviary/segments.py
@@ -109,8 +109,8 @@ class MessageLayer(nn.Module):
         super().__init__()
 
         self._repr = (
-            f"{self._get_name()}(msg_fea_len={msg_fea_len}, "
-            f"num_msg_heads={num_msg_heads}, msg_gate_layers={msg_gate_layers}, msg_net_layers={msg_net_layers})"
+            f"{self._get_name()}(msg_fea_len={msg_fea_len}, num_msg_heads={num_msg_heads}, "
+            f"msg_gate_layers={msg_gate_layers}, msg_net_layers={msg_net_layers})"
         )
 
         # Pooling and Output
@@ -181,7 +181,8 @@ class SimpleNetwork(nn.Module):
             input_dim (int): Number of input features
             output_dim (int): Number of output features
             hidden_layer_dims (list[int]): List of hidden layer sizes
-            activation (type[nn.Module], optional): Which activation function to use. Defaults to nn.LeakyReLU.
+            activation (type[nn.Module], optional): Which activation function to use.
+                Defaults to nn.LeakyReLU.
             batchnorm (bool, optional): Whether to use batchnorm. Defaults to False.
         """
         super().__init__()
@@ -241,7 +242,8 @@ class ResidualNetwork(nn.Module):
             input_dim (int): Number of input features
             output_dim (int): Number of output features
             hidden_layer_dims (list[int]): List of hidden layer sizes
-            activation (type[nn.Module], optional): Which activation function to use. Defaults to nn.LeakyReLU.
+            activation (type[nn.Module], optional): Which activation function to use.
+                Defaults to nn.LeakyReLU.
             batchnorm (bool, optional): Whether to use batchnorm. Defaults to False.
         """
         super().__init__()

--- a/aviary/segments.py
+++ b/aviary/segments.py
@@ -42,7 +42,8 @@ class AttentionPooling(nn.Module):
         return out
 
     def __repr__(self) -> str:
-        return self.__class__.__name__
+        gate_nn, message_nn = self.gate_nn, self.message_nn
+        return f"{type(self).__name__}(gate_nn={gate_nn}, message_nn={message_nn})"
 
 
 class WeightedAttentionPooling(nn.Module):
@@ -83,7 +84,8 @@ class WeightedAttentionPooling(nn.Module):
         return out
 
     def __repr__(self) -> str:
-        return self.__class__.__name__
+        pow, gate_nn, message_nn = float(self.pow), self.gate_nn, self.message_nn
+        return f"{type(self).__name__}(pow={pow:.3}, gate_nn={gate_nn}, message_nn={message_nn})"
 
 
 class MessageLayer(nn.Module):
@@ -216,7 +218,10 @@ class SimpleNetwork(nn.Module):
         self.fc_out.reset_parameters()
 
     def __repr__(self) -> str:
-        return self.__class__.__name__
+        return (
+            f"{type(self).__name__}(input_dim={self.fcs[0].in_features}, "
+            f"output_dim={self.fc_out.out_features}, activation={type(self.acts[0]).__name__})"
+        )
 
 
 class ResidualNetwork(nn.Module):
@@ -274,4 +279,7 @@ class ResidualNetwork(nn.Module):
         return self.fc_out(x)
 
     def __repr__(self) -> str:
-        return self.__class__.__name__
+        return (
+            f"{type(self).__name__}(input_dim={self.fcs[0].in_features}, "
+            f"output_dim={self.fc_out.out_features}, activation={type(self.acts[0]).__name__})"
+        )

--- a/aviary/wren/data.py
+++ b/aviary/wren/data.py
@@ -88,7 +88,8 @@ class WyckoffData(Dataset):
         return len(self.df)
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}(df={self.df.shape}, task_dict={self.task_dict})"
+        df_repr = f"cols=[{', '.join(self.df.columns)}], len={len(self.df)}"
+        return f"{type(self).__name__}({df_repr}, task_dict={self.task_dict})"
 
     @functools.lru_cache(maxsize=None)  # Cache loaded structures
     def __getitem__(self, idx: int):

--- a/aviary/wren/data.py
+++ b/aviary/wren/data.py
@@ -84,8 +84,11 @@ class WyckoffData(Dataset):
                 n_classes = np.max(self.df[target].values) + 1
                 self.n_targets.append(n_classes)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.df)
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(df={self.df.shape}, task_dict={self.task_dict})"
 
     @functools.lru_cache(maxsize=None)  # Cache loaded structures
     def __getitem__(self, idx: int):

--- a/aviary/wren/data.py
+++ b/aviary/wren/data.py
@@ -186,7 +186,6 @@ def collate_batch(
             tuple[Tensor, Tensor, Tensor, LongTensor, LongTensor, LongTensor, LongTensor]:
                 batched Wren model inputs,
             tuple[Tensor | LongTensor]: Target values for different tasks,
-            # TODO this last tuple is unpacked how to do type hint? not sure I understand ... in type hints
             *tuple[str | int]]: Identifiers like material_id, composition
         ]
     """

--- a/aviary/wren/model.py
+++ b/aviary/wren/model.py
@@ -151,7 +151,7 @@ class Wren(BaseModelClass):
 
 
 class DescriptorNetwork(nn.Module):
-    """The Descriptor Network is the message passing section of the Roost Model."""
+    """The Descriptor Network is the message passing section of the Roost model."""
 
     def __init__(
         self,
@@ -167,7 +167,7 @@ class DescriptorNetwork(nn.Module):
         cry_gate: Sequence[int] = (256,),
         cry_msg: Sequence[int] = (256,),
     ):
-        """_summary_
+        """Message passing section of the Roost model.
 
         Args:
             elem_emb_len (int): Number of features in initial element embedding
@@ -182,7 +182,7 @@ class DescriptorNetwork(nn.Module):
                 operation. Defaults to 1.
             elem_gate (list[int], optional): _description_. Defaults to [256].
             elem_msg (list[int], optional): _description_. Defaults to [256].
-            cry_heads (int, optional): _description_. Defaults to 1.
+            cry_heads (int, optional): Number of attention heads. Defaults to 1.
             cry_gate (list[int], optional): _description_. Defaults to [256].
             cry_msg (list[int], optional): _description_. Defaults to [256].
         """
@@ -269,6 +269,7 @@ class DescriptorNetwork(nn.Module):
 
     def __repr__(self) -> str:
         return (
-            f"{type(self).__name__}(elem_emb_len={self.elem_emb_len}, "
+            f"{type(self).__name__}(n_graph={len(self.graphs)}, cry_heads="
+            f"{len(self.cry_pool)}, elem_emb_len={self.elem_emb_len}, "
             f"sym_emb_len={self.sym_emb_len})"
         )

--- a/aviary/wren/model.py
+++ b/aviary/wren/model.py
@@ -42,15 +42,8 @@ class Wren(BaseModelClass):
         cry_heads: int = 1,
         cry_gate: Sequence[int] = (256,),
         cry_msg: Sequence[int] = (256,),
-        trunk_hidden: Sequence[int] = (
-            1024,
-            512,
-        ),
-        out_hidden: Sequence[int] = (
-            256,
-            128,
-            64,
-        ),
+        trunk_hidden: Sequence[int] = (1024, 512),
+        out_hidden: Sequence[int] = (256, 128, 64),
         **kwargs,
     ) -> None:
         """_summary_
@@ -60,10 +53,14 @@ class Wren(BaseModelClass):
             n_targets (list[int]): Number of targets to train on
             elem_emb_len (int): Number of features in initial element embedding
             sym_emb_len (int): Number of features in initial Wyckoff letter embedding
-            elem_fea_len (int, optional): Number of hidden features to use to encode elements. Defaults to 32.
-            sym_fea_len (int, optional): Number of hidden features to use to encode Wyckoff letters. Defaults to 32.
-            n_graph (int, optional): Number of message passing operations to carry out. Defaults to 3.
-            elem_heads (int, optional): Number of parallel attention heads per message passing operation. Defaults to 1.
+            elem_fea_len (int, optional): Number of hidden features to use to encode elements.
+                Defaults to 32.
+            sym_fea_len (int, optional): Number of hidden features to use to encode Wyckoff letters.
+                Defaults to 32.
+            n_graph (int, optional): Number of message passing operations to carry out.
+                Defaults to 3.
+            elem_heads (int, optional): Number of parallel attention heads per message passing
+                operation. Defaults to 1.
             elem_gate (list[int], optional): _description_. Defaults to [256].
             elem_msg (list[int], optional): _description_. Defaults to [256].
             cry_heads (int, optional): _description_. Defaults to 1.
@@ -175,10 +172,14 @@ class DescriptorNetwork(nn.Module):
         Args:
             elem_emb_len (int): Number of features in initial element embedding
             sym_emb_len (int): Number of features in initial Wyckoff letter embedding
-            elem_fea_len (int, optional): Number of hidden features to use to encode elements. Defaults to 32.
-            sym_fea_len (int, optional): Number of hidden features to use to encode Wyckoff letters. Defaults to 32.
-            n_graph (int, optional): Number of message passing operations to carry out. Defaults to 3.
-            elem_heads (int, optional): Number of parallel attention heads per message passing operation. Defaults to 1.
+            elem_fea_len (int, optional): Number of hidden features to use to encode elements.
+                Defaults to 32.
+            sym_fea_len (int, optional): Number of hidden features to use to encode Wyckoff letters.
+                Defaults to 32.
+            n_graph (int, optional): Number of message passing operations to carry out.
+                Defaults to 3.
+            elem_heads (int, optional): Number of parallel attention heads per message passing
+                operation. Defaults to 1.
             elem_gate (list[int], optional): _description_. Defaults to [256].
             elem_msg (list[int], optional): _description_. Defaults to [256].
             cry_heads (int, optional): _description_. Defaults to 1.
@@ -267,4 +268,7 @@ class DescriptorNetwork(nn.Module):
         return cry_fea
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}(elem_emb_len={self.elem_emb_len}, sym_emb_len={self.sym_emb_len})"
+        return (
+            f"{type(self).__name__}(elem_emb_len={self.elem_emb_len}, "
+            f"sym_emb_len={self.sym_emb_len})"
+        )

--- a/aviary/wren/model.py
+++ b/aviary/wren/model.py
@@ -267,4 +267,4 @@ class DescriptorNetwork(nn.Module):
         return cry_fea
 
     def __repr__(self) -> str:
-        return self.__class__.__name__
+        return f"{type(self).__name__}(elem_emb_len={self.elem_emb_len}, sym_emb_len={self.sym_emb_len})"


### PR DESCRIPTION
I think #20 didn't go far enough. I'd say it makes sense to include the most important params in reprs for all `nn.Module` subclasses.

Example of before and after

```py
WeightedAttentionPooling(
    gate_nn=SimpleNetwork(64, 1, [32]),
    message_nn=SimpleNetwork(64, 64, [32]),
)

>>> old: WeightedAttentionPooling
>>> new: WeightedAttentionPooling(
    pow=-0.944,
    gate_nn=SimpleNetwork(input_dim=64, output_dim=1, activation=LeakyReLU),
    message_nn=SimpleNetwork(input_dim=64, output_dim=64, activation=LeakyReLU)
)
```