### PR TITLE
Allow InMemoryDataLoader to store tensors in RAM

### DIFF
--- a/aviary/core.py
+++ b/aviary/core.py
@@ -48,7 +48,7 @@ class BaseModelClass(nn.Module, ABC):
                 loss function to attenuate the weighting of uncertain samples.
             epoch (int, optional): Epoch model training will begin/resume from.
                 Defaults to 0.
-            device 
+            device
             best_val_scores (dict[str, float], optional): Validation score to use for
                 early stopping. Defaults to None.
         """
@@ -279,7 +279,7 @@ class BaseModelClass(nn.Module, ABC):
                 if task == "regression":
                     assert normalizer is not None
                     targets = normalizer.norm(targets).squeeze()  # noqa: PLW2901
-                    targets = targets.to(self.device) # noqa: PLW2901
+                    targets = targets.to(self.device)  # noqa: PLW2901
 
                     if self.robust:
                         preds, log_std = output.unbind(dim=1)
@@ -294,7 +294,7 @@ class BaseModelClass(nn.Module, ABC):
                     target_metrics["MSE"].append(float(error.pow(2).mean()))
 
                 elif task == "classification":
-                    targets = targets.to(self.device) # noqa: PLW2901
+                    targets = targets.to(self.device)  # noqa: PLW2901
 
                     if self.robust:
                         pre_logits, log_std = output.chunk(2, dim=1)
@@ -382,7 +382,10 @@ class BaseModelClass(nn.Module, ABC):
         for inputs, targets, *batch_ids in tqdm(
             data_loader, disable=True if not verbose else None
         ):
-            inputs = [tensor.to(self.device) if hasattr(tensor, "to") else tensor for tensor in inputs]  # noqa: PLW2901
+            inputs = [
+                tensor.to(self.device) if hasattr(tensor, "to") else tensor
+                for tensor in inputs
+            ]  # noqa: PLW2901
             preds = self(*inputs)  # forward pass to get model preds
 
             test_ids.append(batch_ids)
@@ -421,7 +424,10 @@ class BaseModelClass(nn.Module, ABC):
         features = []
 
         for inputs, *_ in data_loader:
-            inputs = [tensor.to(self.device) if hasattr(tensor, "to") else tensor for tensor in inputs]  # noqa: PLW2901
+            inputs = [
+                tensor.to(self.device) if hasattr(tensor, "to") else tensor
+                for tensor in inputs
+            ]  # noqa: PLW2901
             output = self.trunk_nn(self.material_nn(*inputs)).cpu().numpy()
             features.append(output)
 

--- a/aviary/core.py
+++ b/aviary/core.py
@@ -48,7 +48,7 @@ class BaseModelClass(nn.Module, ABC):
                 loss function to attenuate the weighting of uncertain samples.
             epoch (int, optional): Epoch model training will begin/resume from.
                 Defaults to 0.
-            device
+            device (str, optional): Device to store the model parameters on.
             best_val_scores (dict[str, float], optional): Validation score to use for
                 early stopping. Defaults to None.
         """
@@ -382,10 +382,10 @@ class BaseModelClass(nn.Module, ABC):
         for inputs, targets, *batch_ids in tqdm(
             data_loader, disable=True if not verbose else None
         ):
-            inputs = [
+            inputs = [  # noqa: PLW2901
                 tensor.to(self.device) if hasattr(tensor, "to") else tensor
                 for tensor in inputs
-            ]  # noqa: PLW2901
+            ]
             preds = self(*inputs)  # forward pass to get model preds
 
             test_ids.append(batch_ids)
@@ -424,10 +424,10 @@ class BaseModelClass(nn.Module, ABC):
         features = []
 
         for inputs, *_ in data_loader:
-            inputs = [
+            inputs = [  # noqa: PLW2901
                 tensor.to(self.device) if hasattr(tensor, "to") else tensor
                 for tensor in inputs
-            ]  # noqa: PLW2901
+            ]
             output = self.trunk_nn(self.material_nn(*inputs)).cpu().numpy()
             features.append(output)
 

--- a/aviary/train.py
+++ b/aviary/train.py
@@ -277,10 +277,14 @@ def train_model(
                 inference_model(
                     *[
                         tensor.to(inference_model.device)
-                        if hasattr(tensor, "to") else tensor
+                        if hasattr(tensor, "to")
+                        else tensor
                         for tensor in inputs
                     ]
-                )[0].cpu().numpy() for inputs, *_ in test_loader
+                )[0]
+                .cpu()
+                .numpy()
+                for inputs, *_ in test_loader
             ]
         ).squeeze()
 

--- a/aviary/train.py
+++ b/aviary/train.py
@@ -136,6 +136,7 @@ def train_model(
         else (torch.nn.NLLLoss() if robust else torch.nn.CrossEntropyLoss())
     )
     loss_dict = {target_col: (task_type, loss_func)}
+
     normalizer_dict = {target_col: Normalizer() if task_type == reg_key else None}
     # TODO consider actually fitting the normalizer, currently just passed into
     # model.evaluate() to match function signature
@@ -272,7 +273,15 @@ def train_model(
 
     with torch.no_grad():
         preds = np.concatenate(
-            [inference_model(*inputs)[0].cpu().numpy() for inputs, *_ in test_loader]
+            [
+                inference_model(
+                    *[
+                        tensor.to(inference_model.device)
+                        if hasattr(tensor, "to") else tensor
+                        for tensor in inputs
+                    ]
+                )[0].cpu().numpy() for inputs, *_ in test_loader
+            ]
         ).squeeze()
 
     if test_df is None:
@@ -371,6 +380,7 @@ def train_wrenformer(
     id_col: str = "material_id",
     input_col: str | None = None,
     model_params: dict[str, Any] | None = None,
+    data_loader_device: str = "cpu",
     **kwargs,
 ) -> tuple[dict[str, float], dict[str, Any], pd.DataFrame]:
     """Train a Wrenformer model on a dataframe. This function handles the DataLoader
@@ -396,6 +406,7 @@ def train_wrenformer(
             run_name which default to 'wyckoff' and 'composition' respectively.
         model_params (dict): Passed to Wrenformer class. E.g. dict(n_attn_layers=6,
             embedding_aggregation=("mean", "std")).
+        data_loader_device(str): device to store the InMemoryDataLoader's tensors on.
         **kwargs: Additional keyword arguments are passed to train_model().
 
     Returns:
@@ -419,6 +430,7 @@ def train_wrenformer(
         input_col=input_col,
         id_col=id_col,
         embedding_type=embedding_type,
+        device=data_loader_device,
     )
     train_loader = df_to_in_mem_dataloader(
         train_df,


### PR DESCRIPTION
Very large datasets can eat all of the VRAM.